### PR TITLE
Persist job details in db and add author, repo and html_url for request data

### DIFF
--- a/interface/__main__.py
+++ b/interface/__main__.py
@@ -3,7 +3,7 @@
 Run ForgeFed Interface flask application
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/api/__init__.py
+++ b/interface/api/__init__.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/api/v1/__init__.py
+++ b/interface/api/v1/__init__.py
@@ -2,7 +2,7 @@
 Version 1 API
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/api/v1/issues.py
+++ b/interface/api/v1/issues.py
@@ -2,7 +2,7 @@
 Issues related routes
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/api/v1/notifications.py
+++ b/interface/api/v1/notifications.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/api/v1/repo.py
+++ b/interface/api/v1/repo.py
@@ -2,7 +2,7 @@
 Repository related routes
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/app.py
+++ b/interface/app.py
@@ -2,7 +2,7 @@
 Flask application
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/auth.py
+++ b/interface/auth.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/client.py
+++ b/interface/client.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/__init__.py
+++ b/interface/db/__init__.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/__init__.py
+++ b/interface/db/__init__.py
@@ -20,3 +20,4 @@ from .issues import DBIssue
 from .users import DBUser
 from .subscriptions import DBSubscribe
 from .comments import DBComment
+from .events import DBTask, JobStatus

--- a/interface/db/comments.py
+++ b/interface/db/comments.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/comments.py
+++ b/interface/db/comments.py
@@ -48,6 +48,26 @@ class DBComment:
         """
         self.is_native = bool(self.is_native)
 
+    def __update(self):
+        """
+        Update changes in database
+        Only fields that can be mutated on the forge will be updated in the DB
+        """
+        conn = get_db()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            UPDATE gitea_issue_comments
+            SET
+                body = ?,
+                updated = ?
+            WHERE
+                comment_id = ?;
+            """,
+            (self.body, self.updated, self.comment_id),
+        )
+        conn.commit()
+
     def save(self):
         """Save COmment to database"""
         self.user.save()
@@ -56,8 +76,6 @@ class DBComment:
 
         conn = get_db()
         cur = conn.cursor()
-        print(type(self.comment_id))
-        print(type(self.updated))
         cur.execute(
             """
             INSERT OR IGNORE INTO gitea_issue_comments
@@ -89,6 +107,7 @@ class DBComment:
             ),
         )
         conn.commit()
+        self.__update()
 
     @classmethod
     def load_from_comment_url(cls, comment_url: str) -> "DBComment":

--- a/interface/db/conn.py
+++ b/interface/db/conn.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/events.py
+++ b/interface/db/events.py
@@ -1,0 +1,187 @@
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum, unique
+from uuid import UUID, uuid4
+from sqlite3 import IntegrityError
+
+from .conn import get_db
+from .interfaces import DBInterfaces
+
+
+@unique
+class JobStatus(Enum):
+    """Represents the completion status of a Job"""
+
+    ERROR = -1
+    QUEUED = 0
+    COMPLETED = 1
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class DBTask:
+    """User information as stored in the database"""
+
+    signed_by: DBInterfaces
+    uuid: UUID = uuid4()
+    status: JobStatus = JobStatus.QUEUED
+    created: str = str(datetime.now())
+    updated: str = None
+    id: int = None
+
+    def __update(self):
+        """
+        Save updates to database.
+        Caller is advised to set self.updated to datetime.now()
+        before calling this method, if job status is changed.
+        """
+        self.updated = str(datetime.now())
+        conn = get_db()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            UPDATE tasks
+            SET
+                updated = ?,
+                status = ?
+            WHERE
+                id=?
+            """,
+            (
+                self.updated,
+                self.status.value,
+                self.id,
+            ),
+        )
+        conn.commit()
+
+    def set_completed(self):
+        """Set job status to completed"""
+        self.status = JobStatus.COMPLETED
+        self.__update()
+
+    def set_error(self):
+        """Set job status to error"""
+        self.status = JobStatus.ERROR
+        self.__update()
+
+    def get_status(self) -> JobStatus:
+        """Get job status"""
+        return self.status
+
+    def save(self):
+        """Save message to database"""
+        self.signed_by.save()
+
+        conn = get_db()
+        cur = conn.cursor()
+        while True:
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO tasks
+                        (job_id, status, created, signed_by)
+                    VALUES
+                        (?, ?, ?, (SELECT ID FROM interfaces WHERE url = ?));
+                    """,
+                    (
+                        str(self.uuid),
+                        self.status.value,
+                        self.created,
+                        self.signed_by.url,
+                    ),
+                )
+                conn.commit()
+                data = cur.execute(
+                    """
+                    SELECT ID FROM tasks
+                    WHERE
+                        job_id = ?
+                    AND
+                        signed_by = (SELECT ID FROM interfaces WHERE url = ?);
+                    """,
+                    (str(self.uuid), self.signed_by.url),
+                ).fetchone()
+                self.id = data[0]
+                break
+            except IntegrityError:
+                self.uuid = uuid4()
+                continue
+
+    @classmethod
+    def load_with_job_id(cls, job_id: UUID) -> "DBTask":
+        """Load user from database with the URL of the interface which signed it's creation"""
+        conn = get_db()
+        cur = conn.cursor()
+        data = cur.execute(
+            """
+             SELECT
+                 ID,
+                 status,
+                 created,
+                 updated,
+                 signed_by
+             FROM
+                 tasks
+             WHERE
+                job_id = ?
+            """,
+            (str(job_id),),
+        ).fetchone()
+        if data is None:
+            return None
+        val = cls(
+            signed_by=DBInterfaces.load_from_database_id(data[4]),
+        )
+        val.uuid = job_id
+        val.id = data[0]
+        val.status = JobStatus(data[1])
+        val.created = data[2]
+        val.updated = data[3]
+        return val
+
+    @classmethod
+    def load_job_with_db_id(cls, db_id: int) -> "DBTask":
+        """Load job from database with database ID assigned to the job"""
+        conn = get_db()
+        cur = conn.cursor()
+        data = cur.execute(
+            """
+             SELECT
+                 job_id,
+                 status,
+                 created,
+                 updated,
+                 signed_by
+             FROM
+                 tasks
+             WHERE
+                ID = ?
+            """,
+            (db_id,),
+        ).fetchone()
+        if data is None:
+            return None
+        val = cls(signed_by=DBInterfaces.load_from_database_id(data[4]))
+        val.id = db_id
+        val.uuid = UUID(data[0])
+        val.status = JobStatus(data[1])
+        val.created = data[2]
+        val.updated = data[3]
+        return val

--- a/interface/db/interfaces.py
+++ b/interface/db/interfaces.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/issues.py
+++ b/interface/db/issues.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/issues.py
+++ b/interface/db/issues.py
@@ -56,7 +56,7 @@ class DBIssue:
         sqlite returns 0 for False and 1 for True and is not automatically typecast
         into bools. This method typecasts all bool values of this class.
 
-        To be invoked by every load_* invokation
+        To be invoked by every load_* invocation
         """
         self.is_merged = None if self.is_merged is None else bool(self.is_merged)
         self.is_native = bool(self.is_native)

--- a/interface/db/issues.py
+++ b/interface/db/issues.py
@@ -22,6 +22,10 @@ from .users import DBUser
 from .repo import DBRepo
 from .interfaces import DBInterfaces
 
+OPEN = "open"
+MERGED = "merged"
+CLOSED = "closed"
+
 
 @dataclass
 class DBIssue:
@@ -38,12 +42,115 @@ class DBIssue:
     signed_by: DBInterfaces
     id: int = None
     is_closed: bool = False
+    # is_merged only makes sense for PR, therefore it's absence(=None) is
+    # used to denote the Issue is an Issue and not a PR
     is_merged: bool = None
     #    -- is_native:
     #        -- false: issue is PR and not merged
     #        -- true: issue is PR and merged
     #        -- false && val(is_closed) == true: issue is PR and is closed
     is_native: bool = True
+
+    def __set_sqlite_to_bools(self):
+        """
+        sqlite returns 0 for False and 1 for True and is not automatically typecast
+        into bools. This method typecasts all bool values of this class.
+
+        To be invoked by every load_* invokation
+        """
+        self.is_merged = None if self.is_merged is None else bool(self.is_merged)
+        self.is_native = bool(self.is_native)
+        self.is_closed = bool(self.is_closed)
+
+    def state(self) -> str:
+        """Get state of an issue"""
+        # if is_merged is None, then issue is an Issue and not a PR
+        # since is_merged doesn't make sense for an aissue
+        if self.is_merged is None:
+            # Issue can only assume two states: open and close
+            # So return state only based on is_closed
+            return CLOSED if self.is_closed else OPEN
+
+        # If is_merged is True, then issue is PR and is merged
+        if self.is_merged:
+            return MERGED
+
+        # if is_merged is False then issue is PR and state needs to be
+        # determied based on is_closed
+        return CLOSED if self.is_closed else OPEN
+
+    def is_pr(self) -> bool:
+        """is Issue a PR"""
+        return self.is_merged is not None
+
+    def set_closed(self, updated: str):
+        """
+        Mark an Issue to be closed.
+        """
+        self.is_closed = True
+        self.updated = updated
+        self.__update()
+
+    def set_merged(self, updated: str):
+        """
+        Set PR as merged
+        Since GitHub family of forges close a PR at the same time it's merged,
+        the issue will also be marked as closed. However, the ultimiate state of the
+        PR is said to be "merged"
+        """
+        if self.is_pr():
+            self.is_merged = True
+            self.set_closed(updated)
+        #    commented out because self.is_closed() is already setting updated time
+        #    and committing changes to database but leaving it here for clarity
+        #    self.updated = updated
+        #    self.__update()
+        else:
+            raise TypeError("Issue is not a PR, can't be merged")
+
+    def set_open(self, updated: str):
+        """Re-open an issue"""
+        # TODO I couldn't find an option to revert a commit on Gitea but GitHub
+        # seems to have it. What happens to state in notification if PR is reverted?
+        # I'm assuming that the state would be set to not merged
+        # and not closed but requires investigation.
+        self.is_closed = False
+        self.updated = updated
+        if self.is_pr():
+            self.is_merged = False
+        self.__update()
+
+    def __update(self):
+        """
+        Update changes in database
+        Only fields that can be mutated on the forge will be updated in the DB
+        """
+        conn = get_db()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            UPDATE gitea_forge_issues
+            SET
+                title = ?,
+                description = ?,
+                updated = ?,
+                is_closed = ?,
+                is_merged = ?,
+                signed_by = (SELECT ID from interfaces WHERE url  = ?)
+            WHERE
+                id = ?
+            """,
+            (
+                self.title,
+                self.description,
+                self.updated,
+                self.is_closed,
+                self.is_merged,
+                self.signed_by.url,
+                self.id,
+            ),
+        )
+        conn.commit()
 
     def save(self):
         """Save Issue to database"""
@@ -87,6 +194,18 @@ class DBIssue:
             ),
         )
         conn.commit()
+        self.id = cur.execute(
+            """
+                SELECT id FROM gitea_forge_issues
+                WHERE repo_scope_id = ? AND html_url = ?
+                """,
+            (self.repo_scope_id, self.html_url),
+        ).fetchone()[
+            0
+        ]  # If sqlite result doesn't contain anything at [0]
+        # pos then save wasn't successful or some other
+        # error occurred
+        self.__update()
 
     @classmethod
     def load(cls, repository: DBRepo, repo_scope_id: str) -> "DBIssue":
@@ -140,7 +259,7 @@ class DBIssue:
 
         repository.id = data[17]
 
-        return cls(
+        issue = cls(
             id=data[0],
             title=data[1],
             description=data[2],
@@ -169,6 +288,9 @@ class DBIssue:
             ),
             repository=repository,
         )
+
+        issue.__set_sqlite_to_bools()
+        return issue
 
     @classmethod
     def load_with_id(cls, db_id: str) -> "DBIssue":
@@ -221,7 +343,7 @@ class DBIssue:
         if data is None:
             return None
 
-        return cls(
+        issue = cls(
             id=db_id,
             title=data[0],
             description=data[1],
@@ -254,6 +376,8 @@ class DBIssue:
                 owner=data[21],
             ),
         )
+        issue.__set_sqlite_to_bools()
+        return issue
 
     @classmethod
     def load_with_html_url(cls, html_url: str) -> "DBIssue":
@@ -305,7 +429,7 @@ class DBIssue:
         if data is None:
             return None
 
-        return cls(
+        issue = cls(
             html_url=html_url,
             title=data[0],
             description=data[1],
@@ -338,3 +462,5 @@ class DBIssue:
                 owner=data[21],
             ),
         )
+        issue.__set_sqlite_to_bools()
+        return issue

--- a/interface/db/repo.py
+++ b/interface/db/repo.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/subscriptions.py
+++ b/interface/db/subscriptions.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/db/users.py
+++ b/interface/db/users.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/error.py
+++ b/interface/error.py
@@ -2,7 +2,7 @@
 Errors
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/base.py
+++ b/interface/forges/base.py
@@ -2,7 +2,7 @@
 Forge behavior base class
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/gitea/__init__.py
+++ b/interface/forges/gitea/__init__.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/gitea/admin.py
+++ b/interface/forges/gitea/admin.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/gitea/gitea.py
+++ b/interface/forges/gitea/gitea.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/gitea/gitea.py
+++ b/interface/forges/gitea/gitea.py
@@ -38,6 +38,7 @@ from interface.utils import trim_url, clean_url, get_rand
 
 from .html_client import HTMLClient
 from .utils import get_issue_index
+from .responses import GiteaIssue
 
 
 class Gitea(Forge):
@@ -60,6 +61,10 @@ class Gitea(Forge):
         path = f"{prefix}{path}"
         url = urlunparse((self.host.scheme, self.host.netloc, path, "", "", ""))
         return url
+
+    @staticmethod
+    def get_issue(issue_url: str) -> GiteaIssue:
+        return GiteaIssue.get_issue(issue_url)
 
     def get_issues(
         self, owner: str, repo: str, since: datetime.datetime = None, *args, **kwargs

--- a/interface/forges/gitea/html_client.py
+++ b/interface/forges/gitea/html_client.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/gitea/notifications.py
+++ b/interface/forges/gitea/notifications.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/gitea/responses.py
+++ b/interface/forges/gitea/responses.py
@@ -1,0 +1,272 @@
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from dataclasses import dataclass
+
+import requests
+
+# from flask import current_app
+from dynaconf import settings
+
+#
+# from interface.forges.notifications import (
+#    CreatePrEvent,
+#    CreatePrMessage,
+#    NotificationResolver,
+#    RunNotification,
+#    Notification,
+#    PrEvent,
+#    IssueEvent,
+# )
+# from interface.forges.gitea.utils import get_issue_index
+# from interface.utils import clean_url, trim_url
+from interface.db import DBRepo, DBIssue, DBUser, DBInterfaces, DBComment
+from interface.utils import clean_url, trim_url
+
+from .utils import get_issue_index
+from .admin import get_db_interface
+
+
+@dataclass
+class GiteaInternalTracker:
+    enable_time_tracker: bool
+    allow_only_contributors_to_track_time: bool
+    enable_issue_dependencies: bool
+
+
+@dataclass
+class GiteaRepoPermissions:
+    admin: bool
+    push: bool
+    pull: bool
+
+
+@dataclass
+class GiteaOwner:
+    id: int
+    login: str
+    full_name: str
+    email: str
+    avatar_url: str
+    language: str
+    is_admin: bool
+    last_login: str
+    created: str
+    restricted: bool
+    active: bool
+    prohibit_login: bool
+    location: str
+    website: str
+    description: str
+    visibility: str
+    followers_count: int
+    following_count: int
+    starred_repos_count: int
+    username: str
+
+    def to_db_user(self) -> DBUser:
+        """requires app context"""
+        return DBUser(
+            name=self.full_name,
+            user_id=self.username,
+            profile_url=f"{trim_url(clean_url(settings.GITEA.host))}/{self.username}",
+            signed_by=get_db_interface(),
+        )
+
+
+@dataclass
+class GiteaRepo:
+    id: int
+    owner: GiteaOwner
+    name: str
+    full_name: str
+    description: str
+    empty: bool
+    private: bool
+    fork: bool
+    template: bool
+    parent: str
+    mirror: bool
+    size: int
+    html_url: str
+    ssh_url: str
+    clone_url: str
+    original_url: str
+    website: str
+    stars_count: int
+    forks_count: int
+    watchers_count: int
+    open_issues_count: int
+    open_pr_counter: int
+    release_counter: int
+    default_branch: str
+    archived: bool
+    created_at: str
+    updated_at: str
+    permissions: GiteaRepoPermissions
+    has_issues: bool
+    internal_tracker: GiteaInternalTracker
+    has_wiki: bool
+    has_pull_requests: bool
+    has_projects: bool
+    ignore_whitespace_conflicts: bool
+    allow_merge_commits: bool
+    allow_rebase: bool
+    allow_rebase_explicit: bool
+    allow_squash_merge: bool
+    default_merge_style: str
+    avatar_url: str
+    internal: bool
+    mirror_interval: str
+
+    def to_db_repo(self) -> DBRepo:
+        return DBRepo(name=self.name, owner=self.owner.username)
+
+
+class GiteaNotificationSubject:
+    title: str
+    url: str
+    latest_comment_url: str
+    type: str
+    state: str
+
+
+class GiteaMinimalRepo:
+    id: int
+    name: str
+    full_name: str
+
+    def owner(self) -> str:
+        return self.full_name.split("/")[0]
+
+
+class GiteaIssue:
+    id: int
+    url: str
+    html_url: str
+    number: int
+    user: GiteaOwner
+    original_author: str
+    original_author_id: int
+    title: str
+    body: str
+    ref: str
+    # TODO verify
+    labels: [str]
+    # TODO verify
+    milestone: [str] = None
+    # TODO verify
+    assignee: str = None
+    # TODO verify
+    assignees: [str] = None
+    state: str
+    is_locked: bool
+    comments: int
+    created_at: str
+    updated_at: str
+    closed_at: str
+    due_date: str
+    pull_request: str
+    repository: GiteaMinimalRepo
+
+    @classmethod
+    def get_issue(cls, issue_url: str) -> "GiteaIssue":
+        response = requests.get(issue_url)
+        if response.status_code == 200:
+            return cls(**response.json())
+
+        raise Exception(
+            f"UNKNOWN ERROR while getting issue. Status code {response.status_code}, issue_url {issue_url}"
+        )
+
+    def to_db_issue(self) -> DBIssue:
+        repo = DBRepo(name=self.repository.name, owner=self.repository.owner())
+        is_closed = self.state == "closed"
+        DBIssue(
+            title=self.title,
+            description=self.body,
+            created=self.created_at,
+            html_url=self.html_url,
+            updated=self.updated_at,
+            repository=repo,
+            repo_scope_id=get_issue_index(self.html_url),
+            is_closed=is_closed,
+            # TODO verify is issue is native
+            is_native=True,
+            user=self.user.to_db_user(),
+            signed_by=get_db_interface(),
+        )
+
+
+#    def self_get_comments(self):
+#        if self.comments > 0
+#
+#
+
+
+class GiteaComment:
+    id: int
+    html_url: str
+    pull_request_url: str
+    issue_url: str
+    user: GiteaOwner
+    original_author: str
+    original_author_id: int
+    body: str
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_issue(cls, issue: GiteaIssue) -> "[GiteaComment]":
+        if issue.comments == 0:
+            return None
+
+        comments = []
+        issue_index = get_issue_index(issue.html_url)
+        # TODO use Gitea's(Forge subclass) url bulder
+        resp = requests.get(
+            "{trim_url(clean_url(settings.GITEA.host))}/api/v1/{issue.repository.full_name}/issues/{issue_index}/comments"
+        )
+
+        if resp.status_code == 200:
+            data = resp.json()
+            ## TODO this doesn't take pagination into account
+            for comment in data:
+                comments.append(cls(**comment))
+            return comments
+        raise Exception(
+            f"Error while fetching comments for issue: {issue.html_url} status_code {resp.status_code}"
+        )
+
+    def belongs_to_pull_request(self) -> bool:
+        return len(self.pull_request_url) == 0
+
+    def belongs_to_issue(self) -> bool:
+        return len(self.issue_url) == 0
+
+    def to_db_comment(self) -> DBComment:
+        return DBComment(
+            body=self.body,
+            html_url=self.html_url,
+            user=self.user.to_db_user(),
+            created=self.created_at,
+            updated=self.updated_at,
+            comment_id=self.id,
+            is_native=None,
+            signed_by=get_db_interface(),
+            belongs_to_issue=DBIssue.load_with_html_url(
+                self.issue_url if len(self.pull_request_url) == 0 else self.issue_url
+            ),
+        )

--- a/interface/forges/gitea/utils.py
+++ b/interface/forges/gitea/utils.py
@@ -24,7 +24,7 @@ from interface.forges.base import F_D_INVALID_ISSUE_URL
 
 def get_issue_index(issue_url) -> int:
     """
-    Get isssue index from issue URL
+    Get issue index from issue URL
     https://git.batsense.net/{owner}/{repo}/issues/{id} returns {id}
     """
     issue_frag = "issues/"

--- a/interface/forges/gitea/utils.py
+++ b/interface/forges/gitea/utils.py
@@ -2,7 +2,7 @@
 Gitea-specific utilities
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/github.py
+++ b/interface/forges/github.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 G V Datta Adithya <dat.adithya@gmail.com>
+# Copyright © 2022 G V Datta Adithya <dat.adithya@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/notifications.py
+++ b/interface/forges/notifications.py
@@ -2,7 +2,7 @@
 Notifications payload
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/payload.py
+++ b/interface/forges/payload.py
@@ -29,11 +29,20 @@ class RepositoryInfo:
 
 
 @dataclass
+class Author:
+    username: str
+    name: str
+    profile_url: str
+
+
+@dataclass
 class CreateIssue:
     """Create new issue payload"""
 
     title: str
     body: str
+    author: Author
+    html_url: str
     due_date: str = None
     closed: bool = False
 
@@ -66,4 +75,15 @@ class CreatePullrequest:
     """
     base: str
     title: str
+    html_url: str
+    author: Author
     body: str = None
+
+
+@dataclass
+class CommentOnIssue:
+    """Comment on an Issue or a PR"""
+
+    body: str
+    author: Author
+    html_url: str

--- a/interface/forges/payload.py
+++ b/interface/forges/payload.py
@@ -2,7 +2,7 @@
 Payload data structures
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/forges/utils.py
+++ b/interface/forges/utils.py
@@ -2,7 +2,7 @@
 Utility functions to work with forges
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/git.py
+++ b/interface/git.py
@@ -2,7 +2,7 @@
 Helper class to interact with git repositories
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/meta.py
+++ b/interface/meta.py
@@ -2,7 +2,7 @@
 Meta related routes
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/ns.py
+++ b/interface/ns.py
@@ -2,7 +2,7 @@
 Name service: find interfaces that can work with forges
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/runner/events.py
+++ b/interface/runner/events.py
@@ -2,7 +2,7 @@
 A job runner that receives events(notifications) and runs relevant jobs on them
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/runner/runner.py
+++ b/interface/runner/runner.py
@@ -2,7 +2,7 @@
 A job runner that receives events(notifications) and runs relevant jobs on them
 """
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/interface/utils.py
+++ b/interface/utils.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/libgit/src/error.rs
+++ b/libgit/src/error.rs
@@ -1,6 +1,6 @@
 /* git interface for forgefedv2 interface
  * Bridges software forges to create a distributed software development environment
- * Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+ * Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/libgit/src/lib.rs
+++ b/libgit/src/lib.rs
@@ -1,6 +1,6 @@
 /* git interface for forgefedv2 interface
  * Bridges software forges to create a distributed software development environment
- * Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+ * Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/libgit/src/system.rs
+++ b/libgit/src/system.rs
@@ -1,6 +1,6 @@
 /* git interface for forgefedv2 interface
  * Bridges software forges to create a distributed software development environment
- * Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+ * Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/migrations/20211226_01_zx3oY-forge-data.py
+++ b/migrations/20211226_01_zx3oY-forge-data.py
@@ -47,7 +47,8 @@ steps = [
             repo_scope_id INTEGER NOT NULL,
             user_id INTEGER REFERENCES gitea_users(ID) ON DELETE CASCADE NOT NULL,
             repository INTEGER REFERENCES gitea_forge_repositories(ID) ON DELETE CASCADE NOT NULL,
-            signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL
+            signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL,
+            UNIQUE(repository, repo_scope_id)
         );
     """
     ),

--- a/migrations/20220102_01_q4rHE-events.py
+++ b/migrations/20220102_01_q4rHE-events.py
@@ -1,0 +1,27 @@
+"""
+events
+"""
+
+from yoyo import step
+
+__depends__ = {"20211226_01_zx3oY-forge-data"}
+
+steps = [
+    step(
+        """
+        CREATE TABLE IF NOT EXISTS tasks(
+            ID INTEGER PRIMARY KEY NOT NULL,
+            job_id VARCHAR(36) NOT NULL,
+            signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL,
+            ---  Different values for status:
+            ---     0 = queued
+            ---     1 = completed
+            ---     -1 = error
+            status INTEGER NOT NULL DEFAULT 0,
+            created VARCHAR(40) NOT NULL,
+            updated VARCHAR(40) DEFAULT NULL,
+            UNIQUE(job_id, signed_by)
+        );
+    """
+    )
+]

--- a/tests/api/v1/test_notifications.py
+++ b/tests/api/v1/test_notifications.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/api/v1/test_repo.py
+++ b/tests/api/v1/test_repo.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/db/test_comments.py
+++ b/tests/db/test_comments.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/db/test_comments.py
+++ b/tests/db/test_comments.py
@@ -141,6 +141,8 @@ def test_comment(client):
     comment2.save()
 
     for comment in DBComment.load_issue_comments(issue):
+        from_url = DBComment.load_from_comment_url(comment.html_url)
+        assert cmp_comment(comment, from_url)
         if comment.comment_id == comment1.comment_id:
             assert cmp_comment(comment1, comment)
         else:

--- a/tests/db/test_interface.py
+++ b/tests/db/test_interface.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/db/test_issue.py
+++ b/tests/db/test_issue.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/db/test_repo.py
+++ b/tests/db/test_repo.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/db/test_tasks.py
+++ b/tests/db/test_tasks.py
@@ -1,0 +1,68 @@
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from dynaconf import settings
+
+from interface.auth import KeyPair
+from interface.app import app
+from interface.db import DBInterfaces, JobStatus, DBTask
+
+from .test_interface import cmp_interface
+
+
+def cmp_tasks(lhs: DBTask, rhs: DBTask) -> bool:
+    """Compare two DBTask objects"""
+    return all(
+        [
+            lhs.uuid == rhs.uuid,
+            lhs.status == rhs.status,
+            lhs.created == rhs.created,
+            lhs.updated == rhs.updated,
+            lhs.id == rhs.id,
+            cmp_interface(lhs.signed_by, rhs.signed_by),
+        ]
+    )
+
+
+def test_task(client):
+    """Test DBTask database class"""
+
+    key = KeyPair()
+    url = "https://test_interface.example.com"
+    interface = DBInterfaces(url=url, public_key=key.to_base64_public())
+    interface.save()
+
+    task = DBTask(
+        signed_by=interface,
+    )
+    task.save()
+    from_db_with_db_id = DBTask.load_job_with_db_id(task.id)
+    from_db_with_job_id = DBTask.load_with_job_id(task.uuid)
+    assert cmp_tasks(task, from_db_with_db_id)
+    assert cmp_tasks(task, from_db_with_job_id)
+
+    task.set_error()
+    assert task.get_status() is JobStatus.ERROR
+    assert DBTask.load_job_with_db_id(task.id).get_status() is JobStatus.ERROR
+
+    task.set_completed()
+    assert task.get_status() is JobStatus.COMPLETED
+    assert DBTask.load_job_with_db_id(task.id).get_status() is JobStatus.COMPLETED
+    db_id = task.id
+    uuid = task.uuid
+
+    # A new UUID is created if there's a conflict, check if this works
+    task.save()
+    assert task.id != db_id
+    assert task.uuid != uuid

--- a/tests/db/test_user.py
+++ b/tests/db/test_user.py
@@ -1,5 +1,5 @@
 # Bridges software forges to create a distributed software development environment
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/forges/gitea/test_csrf.py
+++ b/tests/forges/gitea/test_csrf.py
@@ -1,6 +1,6 @@
 """ Test for Gitea CSRF parser"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -20,7 +20,7 @@ import pytest
 
 from interface.utils import get_rand
 from interface.client import GET_REPOSITORY, GET_REPOSITORY_INFO
-from interface.forges.payload import RepositoryInfo, CreateIssue
+from interface.forges.payload import RepositoryInfo, CreateIssue, Author
 from interface.forges.utils import clean_url
 from interface.git import Git, get_forge
 from interface.forges.base import (
@@ -124,8 +124,14 @@ def test_get_issues(requests_mock):
 def test_create_issues(requests_mock):
 
     g = Gitea()
+    author = Author(name="Author", username="author", profile_url="https://example.com")
 
-    payload = CreateIssue(title=CREATE_ISSUE_TITLE, body=CREATE_ISSUE_BODY)
+    payload = CreateIssue(
+        title=CREATE_ISSUE_TITLE,
+        body=CREATE_ISSUE_BODY,
+        author=author,
+        html_url=author.profile_url,
+    )
     html_url = g.create_issue(REPOSITORY_OWNER, REPOSITORY_NAME, payload)
     assert html_url == CREATE_ISSUE_HTML_URL
 

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -20,7 +20,7 @@ import pytest
 
 from interface.utils import get_rand
 from interface.client import GET_REPOSITORY, GET_REPOSITORY_INFO
-from interface.forges.payload import RepositoryInfo, CreateIssue, Author
+from interface.forges.payload import RepositoryInfo, CreateIssue, Author, RepositoryInfo
 from interface.forges.utils import clean_url
 from interface.git import Git, get_forge
 from interface.forges.base import (
@@ -124,10 +124,16 @@ def test_get_issues(requests_mock):
 def test_create_issues(requests_mock):
 
     g = Gitea()
-    author = Author(name="Author", username="author", profile_url="https://example.com")
+    author = Author(
+        name="Author",
+        fqdn_username="author@example.com",
+        profile_url="https://example.com",
+    )
+    repo = RepositoryInfo(name=REPOSITORY_NAME, owner=REPOSITORY_OWNER)
 
     payload = CreateIssue(
         title=CREATE_ISSUE_TITLE,
+        repository=repo,
         body=CREATE_ISSUE_BODY,
         author=author,
         html_url=author.profile_url,
@@ -136,15 +142,21 @@ def test_create_issues(requests_mock):
     assert html_url == CREATE_ISSUE_HTML_URL
 
     with pytest.raises(Error) as error:
+        payload.repository.owner = NON_EXISTENT["owner"]
+        payload.repository.name = NON_EXISTENT["repo"]
         g.create_issue(NON_EXISTENT["owner"], NON_EXISTENT["repo"], payload)
 
     assert pytest_expect_errror(error, F_D_REPOSITORY_NOT_FOUND)
 
     with pytest.raises(Error) as error:
+        payload.repository.owner = FORGE_ERROR["owner"]
+        payload.repository.name = FORGE_ERROR["repo"]
         g.create_issue(FORGE_ERROR["owner"], FORGE_ERROR["repo"], payload)
     assert pytest_expect_errror(error, F_D_FORGE_UNKNOWN_ERROR)
 
     with pytest.raises(Error) as error:
+        payload.repository.owner = FORGE_FORBIDDEN_ERROR["owner"]
+        payload.repository.name = FORGE_FORBIDDEN_ERROR["repo"]
         g.create_issue(
             FORGE_FORBIDDEN_ERROR["owner"], FORGE_FORBIDDEN_ERROR["repo"], payload
         )

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/forges/gitea/test_gitea_utils.py
+++ b/tests/forges/gitea/test_gitea_utils.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/forges/gitea/test_utils.py
+++ b/tests/forges/gitea/test_utils.py
@@ -1,6 +1,6 @@
 """ Utilities for Gitea functionality"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/forges/test_base.py
+++ b/tests/forges/test_base.py
@@ -20,7 +20,12 @@ import pytest
 from dynaconf import settings
 
 from interface.forges.base import Forge
-from interface.forges.payload import CreateIssue, CreatePullrequest, Author
+from interface.forges.payload import (
+    CreateIssue,
+    CreatePullrequest,
+    Author,
+    RepositoryInfo,
+)
 
 
 class BasicForge(Forge):
@@ -34,7 +39,11 @@ class BasicForge(Forge):
 def test_base_forge():
     """test Forge"""
 
-    author = Author(name="Author", username="author", profile_url="https://example.com")
+    author = Author(
+        name="Author",
+        fqdn_username="author@example.com",
+        profile_url="https://example.com",
+    )
 
     with pytest.raises(Exception) as _:
         Forge("ssh://git@foo:x")
@@ -65,6 +74,10 @@ def test_base_forge():
             title="",
             body="",
             author=author,
+            repository=RepositoryInfo(
+                name="",
+                owner="",
+            ),
             html_url=author.profile_url,
         )
         forge.create_issue("", "", issue)
@@ -83,15 +96,16 @@ def test_base_forge():
 
     with pytest.raises(NotImplementedError) as _:
         pr = CreatePullrequest(
-            owner="",
-            message="",
-            repo="",
             head="",
             base="",
             title="",
             body="",
             author=author,
             html_url=author.profile_url,
+            repository=RepositoryInfo(
+                name="",
+                owner="",
+            ),
         )
         forge.create_pull_request(pr=pr)
 

--- a/tests/forges/test_base.py
+++ b/tests/forges/test_base.py
@@ -1,6 +1,6 @@
 """ Test interface handlers"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/forges/test_base.py
+++ b/tests/forges/test_base.py
@@ -20,7 +20,7 @@ import pytest
 from dynaconf import settings
 
 from interface.forges.base import Forge
-from interface.forges.payload import CreateIssue, CreatePullrequest
+from interface.forges.payload import CreateIssue, CreatePullrequest, Author
 
 
 class BasicForge(Forge):
@@ -33,6 +33,8 @@ class BasicForge(Forge):
 
 def test_base_forge():
     """test Forge"""
+
+    author = Author(name="Author", username="author", profile_url="https://example.com")
 
     with pytest.raises(Exception) as _:
         Forge("ssh://git@foo:x")
@@ -59,7 +61,12 @@ def test_base_forge():
         forge.get_issues("", "")
 
     with pytest.raises(NotImplementedError) as _:
-        issue = CreateIssue(title="", body="")
+        issue = CreateIssue(
+            title="",
+            body="",
+            author=author,
+            html_url=author.profile_url,
+        )
         forge.create_issue("", "", issue)
 
     with pytest.raises(NotImplementedError) as _:
@@ -76,7 +83,15 @@ def test_base_forge():
 
     with pytest.raises(NotImplementedError) as _:
         pr = CreatePullrequest(
-            owner="", message="", repo="", head="", base="", title="", body=""
+            owner="",
+            message="",
+            repo="",
+            head="",
+            base="",
+            title="",
+            body="",
+            author=author,
+            html_url=author.profile_url,
         )
         forge.create_pull_request(pr=pr)
 

--- a/tests/forges/test_utils.py
+++ b/tests/forges/test_utils.py
@@ -1,6 +1,6 @@
 """ Test interface handlers"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/meta_utils.py
+++ b/tests/meta_utils.py
@@ -25,7 +25,7 @@ INTERFACE_KEY_URL = "https://interfac9.example.com/_ff/interface/key"
 def mock_version(requests_mock):
     resp = {"versions": VERSIONS}
     requests_mock.get(INTERFACE_VERSION_URL, json=resp)
-    print(f"Registered verison route {INTERFACE_VERSION_URL}")
+    print(f"Registered version route {INTERFACE_VERSION_URL}")
 
 
 KEY = KeyPair()
@@ -35,4 +35,4 @@ public_key = PublicKey(key=KEY.to_base64_public())
 def mock_key(requests_mock):
     resp = asdict(public_key)
     requests_mock.get(INTERFACE_KEY_URL, json=resp)
-    print(f"Registered verison route {INTERFACE_KEY_URL}")
+    print(f"Registered version route {INTERFACE_KEY_URL}")

--- a/tests/meta_utils.py
+++ b/tests/meta_utils.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/runner/test_resolve_notifications.py
+++ b/tests/runner/test_resolve_notifications.py
@@ -1,6 +1,6 @@
 """ Test errors helper class"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -1,6 +1,6 @@
 """Test default headers configuration"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,6 @@
 """ Test errors helper class"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,6 +1,6 @@
 """Test test configuration"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,6 +1,6 @@
 """ Test interface handlers"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_ns.py
+++ b/tests/test_ns.py
@@ -1,5 +1,5 @@
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 """ Test interface handlers"""
 # Interface ---  API-space federation for software forges
-# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
> blocked by #45
## Changes
- `interface.forges.payload.*` use nested datatypes to represent message author and repository info. 

## Addition
- Gitea API response types for comments, issues, user, repository, and notification with persistence capabilities via `interface.db.*` helpers
- `interface.db.events.DBTask`:
  Store message requests in database
  
  Some requests may be long running and so must be scheduled and run asynchronously. Also, async scheduling might cause problems if the program crashes while there are tasks scheduled.
  
  Storing jobs, with metadata like UUID, created time and completion status has lets the requesting check job execution status and the executor to execute jobs in in a chronological order, if necessary.