### PR TITLE
feat: add HTML URL attribute to gitea_forge_repositories table

### DIFF
--- a/interface/forges/base.py
+++ b/interface/forges/base.py
@@ -130,7 +130,7 @@ class Forge:
         """Get notification resolver"""
         raise NotImplementedError
 
-    def get_user(name: str) -> ForgeUser:
+    def get_user(self, name: str) -> ForgeUser:
         """Get local user information"""
         raise NotImplementedError
 

--- a/interface/forges/gitea/gitea.py
+++ b/interface/forges/gitea/gitea.py
@@ -128,6 +128,7 @@ class Gitea(Forge):
             description=data["description"],
             name=data["name"],
             owner=data["owner"]["login"],
+            html_url=data["html_url"],
         )
         return info
 

--- a/interface/forges/payload.py
+++ b/interface/forges/payload.py
@@ -45,7 +45,8 @@ class RepositoryInfo:
 
     name: str
     owner: str
-    description: str = None
+    html_url: str
+    description: str
 
 
 @dataclass

--- a/migrations/20211226_01_zx3oY-forge-data.py
+++ b/migrations/20211226_01_zx3oY-forge-data.py
@@ -28,6 +28,7 @@ steps = [
             name VARCHAR(250) NOT NULL,
             description TEXT NOT NULL,
             ID INTEGER PRIMARY KEY NOT NULL,
+            html_url TEXT NOT NULL UNIQUE,
             private_key TEXT UNIQUE NOT NULL,
             UNIQUE(owner_id, name)
         );

--- a/tests/db/test_comments.py
+++ b/tests/db/test_comments.py
@@ -80,7 +80,12 @@ def test_comment(client):
     # repository data
     repo_name = "repo_name"
     repo_owner = user.user_id
-    repo = DBRepo(name=repo_name, owner=user, description="foo")
+    repo = DBRepo(
+        name=repo_name,
+        owner=user,
+        description="foo",
+        html_url=f"{profile_url}/{repo_name}",
+    )
     repo.save()
 
     title = "Test issue"

--- a/tests/db/test_issue.py
+++ b/tests/db/test_issue.py
@@ -82,7 +82,12 @@ def test_issue(client):
 
     # repository data
     repo_name = "repo_name"
-    repo = DBRepo(name=repo_name, description="foo", owner=user)
+    repo = DBRepo(
+        name=repo_name,
+        description="foo",
+        owner=user,
+        html_url=f"{profile_url}/{repo_name}",
+    )
 
     title = "Test issue"
     description = "foo bar"

--- a/tests/db/test_subscriptions.py
+++ b/tests/db/test_subscriptions.py
@@ -50,7 +50,12 @@ def test_interface(client):
     )
     owner.save()
 
-    repo = DBRepo(name="name", description="description", owner=owner)
+    repo = DBRepo(
+        name="name",
+        description="description",
+        owner=owner,
+        html_url=f"{owner.profile_url}/name",
+    )
     repo.save()
 
     subscriber = DBSubscribe(repository=repo, subscriber=interface)

--- a/tests/db/test_tasks.py
+++ b/tests/db/test_tasks.py
@@ -92,7 +92,9 @@ def test_task(client):
     meta = MetaData(
         html_url="https://github.com/foo/bar/issues/4", interface_url=url, author=author
     )
-    repo = RepositoryInfo(name="foo", owner="bar")
+    repo = RepositoryInfo(
+        name="foo", owner="bar", description="foobar", html_url="dummyurl"
+    )
     comment = CommentOnIssue(
         meta=meta, body="test comment", repository=repo, issue_url=meta.html_url
     )

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -21,7 +21,6 @@ import pytest
 from interface.utils import get_rand
 from interface.client import GET_REPOSITORY, GET_REPOSITORY_INFO
 from interface.forges.payload import (
-    RepositoryInfo,
     CreateIssue,
     Author,
     RepositoryInfo,
@@ -137,7 +136,12 @@ def test_create_issues(requests_mock):
         profile_url="https://example.com",
     )
     meta = MetaData(html_url="", author=author, interface_url="")
-    repo = RepositoryInfo(name=REPOSITORY_NAME, owner=REPOSITORY_OWNER)
+    repo = RepositoryInfo(
+        name=REPOSITORY_NAME,
+        owner=REPOSITORY_OWNER,
+        description="",
+        html_url=author.profile_url,
+    )
 
     payload = CreateIssue(
         title=CREATE_ISSUE_TITLE, repository=repo, body=CREATE_ISSUE_BODY, meta=meta

--- a/tests/forges/test_base.py
+++ b/tests/forges/test_base.py
@@ -52,6 +52,8 @@ def test_base_forge():
         RepositoryInfo(
             name="",
             owner="",
+            description="",
+            html_url="",
         ),
     )
 
@@ -87,6 +89,8 @@ def test_base_forge():
             repository=RepositoryInfo(
                 name="",
                 owner="",
+                html_url="",
+                description="",
             ),
         )
         forge.create_issue(issue)
@@ -126,3 +130,9 @@ def test_base_forge():
     with pytest.raises(NotImplementedError) as _:
         comment = CommentOnIssue(meta=meta, body="", repository=repo, issue_url="")
         forge.comment_on_issue(comment)
+
+    with pytest.raises(NotImplementedError) as _:
+        forge.get_notification_resolver()
+
+    with pytest.raises(NotImplementedError) as _:
+        forge.get_user("")


### PR DESCRIPTION
Mastodon requires AP actor required a HTML-accessible URL to redirect
users who'd rather see the Actor's posts in it's native environment. So
far, we were under the assumption that we could build repository URLs
from just owner and repository names. This works for GitHub family of
forges but not for other kinds of forges as their repository URL pattern
might be different