### PR TITLE
fix: minor issues in PEM JSON serialization and webfinger resource ID

### DIFF
--- a/interface/auth.py
+++ b/interface/auth.py
@@ -125,8 +125,8 @@ class RSAKeyPair:
 
     def to_json_key(self) -> str:
         """new line characters are formatted to \\n"""
-        key = self.public_key().replace("\n", "\\n")
-        return key
+        #        key = self.public_key().replace("\n", "\\n")
+        return self.public_key()
 
     @staticmethod
     def from_json_key(key) -> str:

--- a/interface/db/repo.py
+++ b/interface/db/repo.py
@@ -194,7 +194,7 @@ class DBRepo:
         return actor
 
     def webfinger_subject(self) -> str:
-        subject = f"acct:{self.actor_name()}:{INTERFACE_DOMAIN}"
+        subject = f"acct:{self.actor_name()}@{INTERFACE_DOMAIN}"
         return subject
 
     def webfinger(self):


### PR DESCRIPTION
- fix actor name and domain must be separated with `@` instead of `:`
- fix public_key JSON serialization