### PR TITLE
chore: rm signed by fields

### DIFF
--- a/interface/db/comments.py
+++ b/interface/db/comments.py
@@ -34,10 +34,8 @@ class DBComment:
     is_native: bool
     user: DBUser
     belongs_to_issue: DBIssue
-    signed_by: DBInterfaces
 
     __belongs_to_issue_id: int = None
-    __signed_by_interface_id: int = None
 
     def __set_sqlite_to_bools(self):
         """
@@ -71,7 +69,6 @@ class DBComment:
     def save(self):
         """Save COmment to database"""
         self.user.save()
-        self.signed_by.save()
         self.belongs_to_issue.save()
 
         conn = get_db()
@@ -83,15 +80,14 @@ class DBComment:
 
                     body, html_url, created, updated,
                     comment_id, is_native, user,
-                    belongs_to_issue, signed_by
+                    belongs_to_issue 
 
                 )
                 VALUES (
                     ?, ?, ?, ?,
                     ?, ?,
                     (SELECT ID from gitea_users WHERE user_id  = ?),
-                    (SELECT ID from gitea_forge_issues WHERE html_url  = ?),
-                    (SELECT ID from interfaces WHERE url  = ?)
+                    (SELECT ID from gitea_forge_issues WHERE html_url  = ?)
                 )
             """,
             (
@@ -103,7 +99,6 @@ class DBComment:
                 self.is_native,
                 self.user.user_id,
                 self.belongs_to_issue.html_url,
-                self.signed_by.url,
             ),
         )
         conn.commit()
@@ -123,8 +118,7 @@ class DBComment:
              updated,
              comment_id,
              is_native,
-             user,
-             signed_by
+             user
          FROM
              gitea_issue_comments
          WHERE
@@ -136,7 +130,6 @@ class DBComment:
             return None
 
         user = DBUser.load_with_db_id(data[6])
-        signed_by = DBInterfaces.load_from_database_id(data[7])
         belongs_to_issue = DBIssue.load_with_id(data[1])
         comment = cls(
             body=data[0],
@@ -146,7 +139,6 @@ class DBComment:
             comment_id=data[4],
             is_native=data[5],
             user=user,
-            signed_by=signed_by,
             belongs_to_issue=belongs_to_issue,
         )
         comment.__set_sqlite_to_bools()
@@ -166,8 +158,7 @@ class DBComment:
              updated,
              comment_id,
              is_native,
-             user,
-             signed_by
+             user
          FROM
              gitea_issue_comments
          WHERE
@@ -181,7 +172,6 @@ class DBComment:
         comments = []
         for comment in data:
             user = DBUser.load_with_db_id(comment[6])
-            signed_by = DBInterfaces.load_from_database_id(comment[7])
             comment = cls(
                 body=comment[0],
                 html_url=comment[1],
@@ -190,7 +180,6 @@ class DBComment:
                 comment_id=comment[4],
                 is_native=comment[5],
                 user=user,
-                signed_by=signed_by,
                 belongs_to_issue=issue,
             )
             comment.__set_sqlite_to_bools()

--- a/interface/db/issues.py
+++ b/interface/db/issues.py
@@ -42,7 +42,6 @@ class DBIssue:
     repo_scope_id: str
     repository: DBRepo
     user: DBUser
-    signed_by: DBInterfaces
     id: int = None
     is_closed: bool = False
     # is_merged only makes sense for PR, therefore it's absence(=None) is
@@ -139,8 +138,7 @@ class DBIssue:
                 description = ?,
                 updated = ?,
                 is_closed = ?,
-                is_merged = ?,
-                signed_by = (SELECT ID from interfaces WHERE url  = ?)
+                is_merged = ?
             WHERE
                 id = ?
             """,
@@ -150,7 +148,6 @@ class DBIssue:
                 self.updated,
                 self.is_closed,
                 self.is_merged,
-                self.signed_by.url,
                 self.id,
             ),
         )
@@ -169,7 +166,6 @@ class DBIssue:
             return
 
         self.user.save()
-        self.signed_by.save()
         self.repository.save()
 
         conn = get_db()
@@ -185,7 +181,7 @@ class DBIssue:
                         (
                             title, description, html_url, created,
                             updated, is_closed, is_merged, is_native,
-                            repo_scope_id, user_id, repository, signed_by, private_key
+                            repo_scope_id, user_id, repository, private_key
                         )
                         VALUES (
                             ?, ?, ?, ?,
@@ -193,7 +189,6 @@ class DBIssue:
                             ?,
                             (SELECT ID FROM gitea_users WHERE user_id  = ?),
                             ?,
-                            (SELECT ID FROM interfaces WHERE url  = ?),
                             ?
                         )
                     """,
@@ -209,7 +204,6 @@ class DBIssue:
                         self.repo_scope_id,
                         self.user.user_id,
                         self.repository.id,
-                        self.signed_by.url,
                         self.private_key.private_key(),
                     ),
                 )
@@ -252,8 +246,6 @@ class DBIssue:
              is_merged,
              is_native,
              user_id,
-             signed_by,
-             repository,
              private_key
         FROM
              gitea_forge_issues
@@ -268,7 +260,6 @@ class DBIssue:
             return None
 
         user = DBUser.load_with_db_id(data[9])
-        signed_by = DBInterfaces.load_from_database_id(data[10])
 
         issue = cls(
             id=data[0],
@@ -282,9 +273,8 @@ class DBIssue:
             is_native=data[8],
             repo_scope_id=repo_scope_id,
             user=user,
-            signed_by=signed_by,
             repository=repository,
-            private_key=RSAKeyPair.load_private_from_str(data[12]),
+            private_key=RSAKeyPair.load_private_from_str(data[10]),
         )
 
         issue.__set_sqlite_to_bools()
@@ -311,7 +301,6 @@ class DBIssue:
              is_native,
              repo_scope_id,
              user_id,
-             signed_by,
              repository,
              private_key
         FROM
@@ -325,8 +314,7 @@ class DBIssue:
             return None
 
         user = DBUser.load_with_db_id(data[9])
-        signed_by = DBInterfaces.load_from_database_id(data[10])
-        repository = DBRepo.load_with_id(data[11])
+        repository = DBRepo.load_with_id(data[10])
 
         issue = cls(
             id=db_id,
@@ -340,9 +328,8 @@ class DBIssue:
             is_native=data[7],
             repo_scope_id=data[8],
             user=user,
-            signed_by=signed_by,
             repository=repository,
-            private_key=RSAKeyPair.load_private_from_str(data[12]),
+            private_key=RSAKeyPair.load_private_from_str(data[11]),
         )
         issue.__set_sqlite_to_bools()
         return issue
@@ -367,7 +354,6 @@ class DBIssue:
              is_native,
              repo_scope_id,
              user_id,
-             signed_by,
              repository,
              private_key
         FROM
@@ -381,8 +367,7 @@ class DBIssue:
             return None
 
         user = DBUser.load_with_db_id(data[9])
-        signed_by = DBInterfaces.load_from_database_id(data[10])
-        repository = DBRepo.load_with_id(data[11])
+        repository = DBRepo.load_with_id(data[10])
 
         issue = cls(
             html_url=html_url,
@@ -396,9 +381,8 @@ class DBIssue:
             is_native=data[7],
             repo_scope_id=data[8],
             user=user,
-            signed_by=signed_by,
             repository=repository,
-            private_key=RSAKeyPair.load_private_from_str(data[12]),
+            private_key=RSAKeyPair.load_private_from_str(data[11]),
         )
         issue.__set_sqlite_to_bools()
         return issue

--- a/interface/db/users.py
+++ b/interface/db/users.py
@@ -33,14 +33,11 @@ class DBUser:
     profile_url: str
     avatar_url: str
     description: str
-    signed_by: DBInterfaces
     id: int = None
     private_key: RSAKeyPair = None
 
     def save(self):
         """Save user to database"""
-        self.signed_by.save()
-
         user = self.load(self.user_id)
         if user is not None:
             self.private_key = user.private_key
@@ -58,11 +55,10 @@ class DBUser:
                     INSERT INTO gitea_users
                         (
                             name, user_id, profile_url,
-                            avatar_url, signed_by, private_key,
+                            avatar_url, private_key,
                             description
                         ) VALUES (
                             ?, ?, ?, ?, 
-                            (SELECT ID from interfaces WHERE url = ?),
                             ?, ?
                         );
                     """,
@@ -71,7 +67,6 @@ class DBUser:
                         self.user_id,
                         self.profile_url,
                         self.avatar_url,
-                        self.signed_by.url,
                         self.private_key.private_key(),
                         self.description,
                     ),
@@ -97,7 +92,6 @@ class DBUser:
                  profile_url,
                  private_key,
                  avatar_url,
-                 signed_by,
                  description
              FROM
                  gitea_users
@@ -109,15 +103,13 @@ class DBUser:
         if data is None:
             return None
 
-        signed_by = DBInterfaces.load_from_database_id(data[5])
         res = cls(
             id=data[0],
             name=data[1],
             user_id=user_id,
             profile_url=data[2],
             avatar_url=data[4],
-            signed_by=signed_by,
-            description=data[6],
+            description=data[5],
         )
         res.private_key = RSAKeyPair.load_private_from_str(data[3])
         return res
@@ -138,7 +130,6 @@ class DBUser:
                  profile_url,
                  private_key,
                  avatar_url,
-                 signed_by,
                  description
              FROM
                  gitea_users
@@ -149,16 +140,13 @@ class DBUser:
         if data is None:
             return None
 
-        signed_by = DBInterfaces.load_from_database_id(data[5])
-
         res = cls(
             user_id=data[0],
             name=data[1],
             id=db_id,
             profile_url=data[2],
             avatar_url=data[4],
-            signed_by=signed_by,
-            description=data[6],
+            description=data[5],
         )
         res.private_key = RSAKeyPair.load_private_from_str(data[3])
         return res

--- a/interface/forges/gitea/admin.py
+++ b/interface/forges/gitea/admin.py
@@ -31,7 +31,6 @@ def get_db_user() -> DBInterfaces:
             name=username,
             user_id=username,
             profile_url=profile_url,
-            signed_by=interface,
             avatar_url="https://git.batsense.net/avatar/a4edc8a838d6e28ddc38ab12aeb9d9cd?size=1160",
             description="ForgeFlux bot",
         )

--- a/interface/forges/gitea/responses.py
+++ b/interface/forges/gitea/responses.py
@@ -82,7 +82,6 @@ class GiteaOwner:
             name=self.full_name,
             user_id=self.username,
             profile_url=f"{trim_url(clean_url(settings.GITEA.host))}/{self.username}",
-            signed_by=get_db_interface(),
             description=self.description,
             avatar_url=self.avatar_url,
         )
@@ -210,7 +209,6 @@ class GiteaIssue:
             # TODO verify is issue is native
             is_native=True,
             user=self.user.to_db_user(),
-            signed_by=get_db_interface(),
         )
 
 
@@ -269,7 +267,6 @@ class GiteaComment:
             updated=self.updated_at,
             comment_id=self.id,
             is_native=None,
-            signed_by=get_db_interface(),
             belongs_to_issue=DBIssue.load_with_html_url(
                 self.issue_url if len(self.pull_request_url) == 0 else self.issue_url
             ),

--- a/interface/forges/payload.py
+++ b/interface/forges/payload.py
@@ -75,7 +75,6 @@ class ForgeUser:
             profile_url=self.profile_url,
             avatar_url=self.avatar_url,
             description=self.description,
-            signed_by=get_db_interface(),
         )
 
 

--- a/migrations/20211226_01_zx3oY-forge-data.py
+++ b/migrations/20211226_01_zx3oY-forge-data.py
@@ -16,8 +16,7 @@ steps = [
             profile_url TEXT UNIQUE NOT NULL,
             avatar_url TEXT NOT NULL,
             description TEXT NOT NULL,
-            private_key TEXT UNIQUE NOT NULL,
-            signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL
+            private_key TEXT UNIQUE NOT NULL
         );
     """
     ),
@@ -54,7 +53,6 @@ steps = [
             repo_scope_id INTEGER NOT NULL,
             user_id INTEGER REFERENCES gitea_users(ID) ON DELETE CASCADE NOT NULL,
             repository INTEGER REFERENCES gitea_forge_repositories(ID) ON DELETE CASCADE NOT NULL,
-            signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL,
             UNIQUE(repository, repo_scope_id)
         );
     """
@@ -70,8 +68,7 @@ steps = [
             comment_id INTEGER NOT NULL UNIQUE,
             is_native BOOLEAN NOT NULL DEFAULT TRUE,
             user INTEGER REFERENCES gitea_users(ID) ON DELETE CASCADE NOT NULL,
-            belongs_to_issue INTEGER REFERENCES gitea_forge_issues(ID) ON DELETE CASCADE NOT NULL,
-            signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL
+            belongs_to_issue INTEGER REFERENCES gitea_forge_issues(ID) ON DELETE CASCADE NOT NULL
         );
     """
     ),

--- a/migrations/20220102_01_q4rHE-events.py
+++ b/migrations/20220102_01_q4rHE-events.py
@@ -12,7 +12,7 @@ steps = [
         CREATE TABLE IF NOT EXISTS tasks(
             ID INTEGER PRIMARY KEY NOT NULL,
             job_id VARCHAR(36) NOT NULL,
-            signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL,
+            scheduled_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE NOT NULL,
             ---  Different values for status:
             ---     0 = queued
             ---     1 = completed
@@ -20,7 +20,7 @@ steps = [
             status INTEGER NOT NULL DEFAULT 0,
             created VARCHAR(40) NOT NULL,
             updated VARCHAR(40) DEFAULT NULL,
-            UNIQUE(job_id, signed_by)
+            UNIQUE(job_id, scheduled_by)
         );
     """
     ),

--- a/tests/db/test_comments.py
+++ b/tests/db/test_comments.py
@@ -15,7 +15,6 @@
 from datetime import datetime
 
 from interface.db import get_db
-from interface.db.interfaces import DBInterfaces
 from interface.db.repo import DBRepo
 from interface.db.issues import DBIssue
 from interface.db.users import DBUser
@@ -23,7 +22,6 @@ from interface.db.comments import DBComment
 
 from tests.db.test_user import cmp_user
 from tests.db.test_issue import cmp_issue
-from tests.db.test_interface import cmp_interface
 
 
 def cmp_comment(lhs: DBComment, rhs: DBComment) -> bool:
@@ -37,25 +35,15 @@ def cmp_comment(lhs: DBComment, rhs: DBComment) -> bool:
             lhs.updated == rhs.updated,
             lhs.is_native == rhs.is_native,
             cmp_user(lhs.user, rhs.user),
-            cmp_interface(lhs.signed_by, rhs.signed_by),
             cmp_issue(lhs.belongs_to_issue, rhs.belongs_to_issue),
             lhs.comment_id == rhs.comment_id,
             lhs.html_url == rhs.html_url,
-            lhs.signed_by.url == rhs.signed_by.url,
         ]
     )
 
 
 def test_comment(client):
     """Test user route"""
-
-    # first interface data
-    interface_url1 = "https://db-test-issue.example.com"
-    interface1 = DBInterfaces(url=interface_url1)
-
-    # second interface data
-    interface_url2 = "https://db-test-issue2.example.com"
-    interface2 = DBInterfaces(url=interface_url2)
 
     # user data signed by interface1
     username = "db_test_user"
@@ -67,7 +55,6 @@ def test_comment(client):
         profile_url=profile_url,
         avatar_url=profile_url,
         description="description",
-        signed_by=interface1,
         id=None,
     )
     user.save()
@@ -89,8 +76,6 @@ def test_comment(client):
     html_url = f"https://git.batsense/{repo_owner}/{repo_name}/issues/{repo_scope_id}"
     created = str(datetime.now())
     updated = str(datetime.now())
-    # repository= repo
-    # signed_by = interface2
     is_closed = False
     is_merged = None
     is_native = True
@@ -104,7 +89,6 @@ def test_comment(client):
         repo_scope_id=repo_scope_id,
         repository=repo,
         user=user,
-        signed_by=interface2,
         is_closed=is_closed,
         is_merged=is_merged,
         is_native=is_native,
@@ -119,7 +103,6 @@ def test_comment(client):
         created=str(datetime.now()),
         updated=str(datetime.now()),
         is_native=True,
-        signed_by=interface1,
         belongs_to_issue=issue,
         user=user,
         html_url=comment_url1,
@@ -138,7 +121,6 @@ def test_comment(client):
         created=str(datetime.now()),
         updated=str(datetime.now()),
         is_native=True,
-        signed_by=interface1,
         belongs_to_issue=issue,
         user=user,
         html_url=comment_url2,

--- a/tests/db/test_issue.py
+++ b/tests/db/test_issue.py
@@ -17,12 +17,10 @@ from datetime import datetime
 import pytest
 
 from interface.db import get_db
-from interface.db.interfaces import DBInterfaces
 from interface.db.repo import DBRepo
 from interface.db.issues import DBIssue, OPEN, MERGED, CLOSED
 from interface.db.users import DBUser
 
-from .test_interface import cmp_interface
 from .test_repo import cmp_repo
 from .test_user import cmp_user
 
@@ -44,21 +42,12 @@ def cmp_issue(lhs: DBIssue, rhs: DBIssue) -> bool:
             lhs.is_native == rhs.is_native,
             cmp_repo(lhs.repository, rhs.repository),
             cmp_user(lhs.user, rhs.user),
-            cmp_interface(lhs.signed_by, rhs.signed_by),
         ]
     )
 
 
 def test_issue(client):
     """Test user route"""
-
-    # first interface data
-    interface_url1 = "https://db-test-issue.example.com"
-    interface1 = DBInterfaces(url=interface_url1)
-
-    # second interface data
-    interface_url2 = "https://db-test-issue2.example.com"
-    interface2 = DBInterfaces(url=interface_url2)
 
     # user data signed by interface1
     username = "db_test_user"
@@ -70,7 +59,6 @@ def test_issue(client):
         profile_url=profile_url,
         avatar_url=profile_url,
         description="description",
-        signed_by=interface1,
         id=None,
     )
 
@@ -92,7 +80,6 @@ def test_issue(client):
     created = str(datetime.now())
     updated = str(datetime.now())
     # repository= repo
-    # signed_by = interface2
     is_closed = False
     is_merged = None
     is_native = True
@@ -106,7 +93,6 @@ def test_issue(client):
         repo_scope_id=repo_scope_id,
         repository=repo,
         user=user,
-        signed_by=interface2,
         is_closed=is_closed,
         is_merged=is_merged,
         is_native=is_native,
@@ -130,7 +116,6 @@ def test_issue(client):
         repo_scope_id=pr_repo_scope_id,
         repository=repo,
         user=user,
-        signed_by=interface2,
         is_closed=is_closed,
         is_merged=False,
         is_native=is_native,

--- a/tests/db/test_repo.py
+++ b/tests/db/test_repo.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import pytest
 
-from interface.db import DBRepo, DBUser, DBInterfaces
+from interface.db import DBRepo, DBUser
 
 from .test_user import cmp_user
 
@@ -36,10 +36,6 @@ def cmp_repo(lhs: DBRepo, rhs: DBRepo) -> bool:
 def test_repo(client):
     """Test repo"""
 
-    # first interface data
-    interface_url1 = "https://db-test-issue.example.com"
-    interface1 = DBInterfaces(url=interface_url1)
-
     # user data signed by interface1
     username = "db_test_user"
     user_id = f"{username}@git.batsense.net"
@@ -50,7 +46,6 @@ def test_repo(client):
         profile_url=profile_url,
         avatar_url=profile_url,
         description="description",
-        signed_by=interface1,
         id=None,
     )
 

--- a/tests/db/test_tasks.py
+++ b/tests/db/test_tasks.py
@@ -30,7 +30,7 @@ def cmp_tasks(lhs: DBTask, rhs: DBTask) -> bool:
             lhs.created == rhs.created,
             lhs.updated == rhs.updated,
             lhs.id == rhs.id,
-            cmp_interface(lhs.signed_by, rhs.signed_by),
+            cmp_interface(lhs.scheduled_by, rhs.scheduled_by),
         ]
     )
 
@@ -54,7 +54,7 @@ def test_task(client):
     interface.save()
 
     task = DBTask(
-        signed_by=interface,
+        scheduled_by=interface,
     )
 
     assert DBTask.load_with_db_id(11) is None

--- a/tests/db/test_user.py
+++ b/tests/db/test_user.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from interface.db import get_db
-from interface.db.interfaces import DBInterfaces
 from interface.db.repo import DBRepo
 from interface.db.issues import DBIssue
 from interface.db.users import DBUser
@@ -31,7 +30,6 @@ def cmp_user(lhs: DBUser, rhs: DBUser) -> bool:
             lhs.profile_url == rhs.profile_url,
             lhs.avatar_url == rhs.avatar_url,
             lhs.description == rhs.description,
-            lhs.signed_by.url == rhs.signed_by.url,
         ]
     )
 
@@ -39,8 +37,6 @@ def cmp_user(lhs: DBUser, rhs: DBUser) -> bool:
 def test_user(client):
     """Test user route"""
 
-    url = "https://db-test-user.example.com"
-    interface = DBInterfaces(url=url)
     name = "db_test_user"
     user_id = name
     user = DBUser(
@@ -49,7 +45,6 @@ def test_user(client):
         profile_url=f"https://git.batsense.net/{user_id}",
         avatar_url=f"https://git.batsense.net/{user_id}",
         description="description",
-        signed_by=interface,
     )
 
     assert DBUser.load(user_id) is None


### PR DESCRIPTION
## Changes
- remove `signed_by` fields from `gitea_users`, `gitea_forge_issues`, `giteagitea_issue_comments`, `gitea_forge_repositories` tables:
This field doesn't make any sense anymore since all messages, if saved in DB, will be signed by the actors that created it. The creator already.
- rename signed_by to scheduled_by in tasks table