### PR TITLE
Forge gitea issue workflow

### DIFF
--- a/interface/db/repo.py
+++ b/interface/db/repo.py
@@ -39,7 +39,6 @@ class DBRepo:
         if repo is not None:
             self.private_key = repo.private_key
             self.id = repo.id
-            print("repo early exit")
             return
 
         self.owner.save()
@@ -69,7 +68,6 @@ class DBRepo:
                 self.id = repo.id
                 break
             except IntegrityError as e:
-                print(e)
                 count += 1
                 if count > 5:
                     raise e
@@ -80,7 +78,6 @@ class DBRepo:
         """Load repository from database"""
         owner = DBUser.load(owner)
         if owner is None:
-            print("owner is none")
             return None
 
         conn = get_db()
@@ -93,7 +90,6 @@ class DBRepo:
             """,
             (name, owner.id),
         ).fetchone()
-        print(data)
         if data is None:
             return None
         resp = cls(name=name, owner=owner, description=data[2], html_url=data[3])

--- a/interface/forges/gitea/gitea.py
+++ b/interface/forges/gitea/gitea.py
@@ -69,8 +69,8 @@ class Gitea(Forge):
         return url
 
     @staticmethod
-    def get_issue(issue_url: str) -> GiteaIssue:
-        return GiteaIssue.get_issue(issue_url)
+    def get_issue(owner: str, repo: str, issue_id) -> GiteaIssue:
+        return GiteaIssue.get_issue(owner=owner, repo=repo, issue_id=issue_id)
 
     @staticmethod
     def get_issue_html_url(owner: str, repo: str, issue_id: str) -> GiteaIssue:

--- a/interface/forges/gitea/utils.py
+++ b/interface/forges/gitea/utils.py
@@ -62,3 +62,8 @@ def get_owner_repo_from_url(url: str) -> (str, str):
 def get_issue_html_url(owner: str, repo: str, issue_id) -> str:
     """issue HTML URL from compoenents"""
     return f"{settings.GITEA.host}/{owner}/{repo}/issues/{issue_id}"
+
+
+def get_issue_api_url(owner: str, repo: str, issue_id) -> str:
+    """issue API URL from compoenents"""
+    return f"{settings.GITEA.host}/api/v1/repos/{owner}/{repo}/issues/{issue_id}"

--- a/interface/utils.py
+++ b/interface/utils.py
@@ -16,7 +16,9 @@
 import random
 import string
 from urllib.parse import urlparse, urlunparse
-from datetime import datetime
+from datetime import datetime, timezone
+
+# from zoneinfo import ZoneInfo
 
 import requests
 
@@ -40,13 +42,14 @@ def get_rand(len: int) -> str:
     )
 
 
-EPOCH = datetime.utcfromtimestamp(0)
+EPOCH = datetime.utcfromtimestamp(0).astimezone(tz=timezone.utc)
 
 
 def since_epoch(date: datetime = None) -> int:
     """Get current time since Unix  epoch in seconds"""
     if not date:
-        date = datetime.now()
+        date = datetime.now(timezone.utc)
+    date.astimezone(tz=timezone.utc)
     return int((date - EPOCH).total_seconds())
 
 
@@ -55,7 +58,7 @@ _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
 def from_epoch(date: int) -> datetime:
     """Get time milliseconds from seconds since Unix epoch"""
-    return datetime.utcfromtimestamp(date)
+    return datetime.utcfromtimestamp(date).astimezone(tz=timezone.utc)
 
 
 def date_from_string(date: str) -> datetime:

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -134,9 +134,16 @@ def test_get_issues(requests_mock):
         g.get_issues(FORGE_ERROR["owner"], FORGE_ERROR["repo"])
     assert pytest_expect_errror(error, F_D_FORGE_UNKNOWN_ERROR)
 
-    signle_issue = g.get_issue(ISSUE_URL)
+    signle_issue = g.get_issue(
+        owner=SINGLE_ISSUE["repository"]["owner"],
+        repo=SINGLE_ISSUE["repository"]["name"],
+        issue_id=SINGLE_ISSUE["number"],
+    )
     assert signle_issue.url == ISSUE_URL
     assert signle_issue.id == SINGLE_ISSUE["id"]
+    signle_issue.get_created_epoch()
+    signle_issue.get_updated_epoch()
+    signle_issue.repo_scope_id()
 
 
 def test_get_comments(requests_mock):
@@ -146,7 +153,11 @@ def test_get_comments(requests_mock):
     assert len(comments) == 3
     assert comments[2].id == 29
     assert comments[2].user.id == USER_INFO["id"]
-    signle_issue = g.get_issue(ISSUE_URL)
+    signle_issue = g.get_issue(
+        owner=SINGLE_ISSUE["repository"]["owner"],
+        repo=SINGLE_ISSUE["repository"]["name"],
+        issue_id=SINGLE_ISSUE["number"],
+    )
     assert GiteaComment.from_issue(signle_issue) == comments
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from urllib.parse import urlparse, urlunparse
-from datetime import datetime
+from datetime import datetime, timezone
 from dynaconf import settings
 
 from interface.app import create_app
@@ -60,8 +60,7 @@ def register_ns(requests_mock):
 
 
 def test_utils():
-    date = datetime(1980, 4, 23, 14, 12, 34)
+    date = datetime(2022, 1, 18, 16, 27, 18, tzinfo=timezone.utc)
     epoch = since_epoch(date=date)
-    print(epoch)
     assert from_epoch(epoch) == date
     assert from_epoch(since_epoch()) > date


### PR DESCRIPTION
> blocked by #69

- rm `GiteaIssue.to_db_issue`: requires additional data for constructing `DBUser` and `DBRepo`
- convert all Gitea response dates to timezone-aware time since epoch
- modifty `Gitea.get_issue` to accept issue identifiers instead of URL