### PR TITLE
feat: lru cache for counting records of generic sqlite table

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -18,7 +18,7 @@ base_dir = "/tmp/" # Location where git repositories will be cloned into
 admin_email = "foo@a.com" # Committing email
 job_runner_delay = 1  ## in seconds
 northstar = "https://northstar.forgefed.io" # Default discovery service URL
-cache_ttl = 3600 # in minutes
+cache_ttl = 3600 # in seconds
 
 [default.server]
 url = "http://localhost:7000" # URL at which this interface will run
@@ -42,7 +42,7 @@ base_dir = "/tmp/" # Location where git repositories will be cloned into
 admin_email = "foo@a.com" # Committing email
 job_runner_delay = 1  ## in seconds
 northstar = "https://northstar.forgeflux.org" # Default discovery service URL
-cache_ttl = 1 # in minutes
+cache_ttl = 1 # in seconds
 
 [testing.server]
 url = "http://localhost:7000" # URL at which this interface will run

--- a/interface/db/cache.py
+++ b/interface/db/cache.py
@@ -1,0 +1,43 @@
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from functools import lru_cache
+
+from dynaconf import settings
+
+from interface.utils import since_epoch
+from .conn import get_db
+
+CACHE_TTL = settings.SYSTEM.cache_ttl  # in seconds
+CACHE_TTL = CACHE_TTL if CACHE_TTL is not None else 1800  # in seconds
+
+
+class RecordCount:
+    def __init__(self, table_name: str):
+        self.table_name = table_name
+
+    @lru_cache(maxsize=1)
+    def __count(self) -> (int, int):
+        conn = get_db()
+        cur = conn.cursor()
+        count = cur.execute(f"SELECT COUNT(*) FROM {self.table_name}").fetchone()[0]
+        return (int(count), since_epoch())
+
+    def count(self) -> int:
+        """Get total number of records stored"""
+        (num, created_at) = self.__count()
+        if since_epoch() - created_at > CACHE_TTL:
+            self.__count.cache_clear()
+            (num, _) = self.__count()
+        return num

--- a/interface/ns.py
+++ b/interface/ns.py
@@ -28,7 +28,7 @@ from interface.error import Error
 
 class NameService:
     __CACHE_TTL = settings.SYSTEM.cache_ttl  # in seconds
-    __CACHE_TTL = __CACHE_TTL if __CACHE_TTL is not None else 3660  # in seconds
+    __CACHE_TTL = __CACHE_TTL if __CACHE_TTL is not None else 3600  # in seconds
 
     @classmethod
     def get_cache_ttl(cls) -> int:


### PR DESCRIPTION
Motivation: Nodeinfo requires user and activity count, computing it every time Nodeinfo is queried could be expensive. Hence, this LRU cache impl 