### PR TITLE
feat: total activity count and monthly and half-yearly active user count

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -18,7 +18,7 @@ base_dir = "/tmp/" # Location where git repositories will be cloned into
 admin_email = "foo@a.com" # Committing email
 job_runner_delay = 1  ## in seconds
 northstar = "https://northstar.forgefed.io" # Default discovery service URL
-cache_ttl = 3600 # in minutes
+cache_ttl = 3600 # in seconds
 
 [default.server]
 url = "http://localhost:7000" # URL at which this interface will run
@@ -42,7 +42,7 @@ base_dir = "/tmp/" # Location where git repositories will be cloned into
 admin_email = "foo@a.com" # Committing email
 job_runner_delay = 1  ## in seconds
 northstar = "https://northstar.forgeflux.org" # Default discovery service URL
-cache_ttl = 1 # in minutes
+cache_ttl = 1 # in seconds
 
 [testing.server]
 url = "http://localhost:7000" # URL at which this interface will run

--- a/interface/db/cache.py
+++ b/interface/db/cache.py
@@ -22,11 +22,10 @@ from .conn import get_db
 CACHE_TTL = settings.SYSTEM.cache_ttl  # in seconds
 CACHE_TTL = CACHE_TTL if CACHE_TTL is not None else 1800  # in seconds
 
-class RecordCount:
 
+class RecordCount:
     def __init__(self, table_name: str):
         self.table_name = table_name
-
 
     @lru_cache(maxsize=1)
     def __count(self) -> (int, int):

--- a/interface/db/cache.py
+++ b/interface/db/cache.py
@@ -1,0 +1,44 @@
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from functools import lru_cache
+
+from dynaconf import settings
+
+from interface.utils import since_epoch
+from .conn import get_db
+
+CACHE_TTL = settings.SYSTEM.cache_ttl  # in seconds
+CACHE_TTL = CACHE_TTL if CACHE_TTL is not None else 1800  # in seconds
+
+class RecordCount:
+
+    def __init__(self, table_name: str):
+        self.table_name = table_name
+
+
+    @lru_cache(maxsize=1)
+    def __count(self) -> (int, int):
+        conn = get_db()
+        cur = conn.cursor()
+        count = cur.execute(f"SELECT COUNT(*) FROM {self.table_name}").fetchone()[0]
+        return (int(count), since_epoch())
+
+    def count(self) -> int:
+        """Get total number of records stored"""
+        (num, created_at) = self.__count()
+        if since_epoch() - created_at > CACHE_TTL:
+            self.__count.cache_clear()
+            (num, _) = self.__count()
+        return num

--- a/interface/db/users.py
+++ b/interface/db/users.py
@@ -21,6 +21,7 @@ from interface.utils import CONTENT_TYPE_ACTIVITY_JSON
 from .conn import get_db
 from .interfaces import DBInterfaces
 from .webfinger import INTERFACE_BASE_URL, INTERFACE_DOMAIN
+from .cache import RecordCount
 
 
 @dataclass
@@ -36,6 +37,8 @@ class DBUser:
     description: str
     id: int = None
     private_key: RSAKeyPair = None
+
+    count = RecordCount("gitea_users")
 
     def save(self):
         """Save user to database"""

--- a/interface/ns.py
+++ b/interface/ns.py
@@ -28,7 +28,7 @@ from interface.error import Error
 
 class NameService:
     __CACHE_TTL = settings.SYSTEM.cache_ttl  # in seconds
-    __CACHE_TTL = __CACHE_TTL if __CACHE_TTL is not None else 3660  # in seconds
+    __CACHE_TTL = __CACHE_TTL if __CACHE_TTL is not None else 3600  # in seconds
 
     @classmethod
     def get_cache_ttl(cls) -> int:

--- a/tests/db/test_activity.py
+++ b/tests/db/test_activity.py
@@ -12,11 +12,15 @@
 # GNU Affero General Public License for more details.
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import time
 from datetime import datetime
 
 import pytest
+from dynaconf import settings
 
 from interface.db import get_db, DBActivity, ActivityType, DBComment
+from interface.db.cache import CACHE_TTL
+from interface.db.activity import ActiveUsersinPeriod
 from interface.db.repo import DBRepo
 from interface.db.issues import DBIssue
 from interface.db.users import DBUser
@@ -42,7 +46,11 @@ def cmp_activity(lhs: DBActivity, rhs: DBActivity) -> bool:
 def test_acitivty(client):
     """Test DBActivity"""
 
+    assert CACHE_TTL < 5  # if this fails, then five_seconds will show more
     assert DBActivity.load_with_db_id(db_id=100) is None
+
+    ttl = settings.SYSTEM.cache_ttl * 2  # in seconds
+    assert DBActivity.count.count() == 0
 
     username = "db_test_user"
     user_id = f"{username}@git.batsense.net"
@@ -94,6 +102,19 @@ def test_acitivty(client):
 
     issue.save()
 
+    five_seconds = ActiveUsersinPeriod(since=5)
+    one_second = ActiveUsersinPeriod(since=1)
+    assert one_second.count() == 1
+    assert five_seconds.count() == 1
+
+    assert DBActivity.count.count() == 0
+    time.sleep(ttl)
+    assert DBActivity.count.count() == 1
+    assert one_second.count() == 0
+    assert five_seconds.count() == 1
+    time.sleep(5)
+    assert five_seconds.count() == 0
+
     with pytest.raises(ValueError):
         DBActivity(user_id=user.id, activity=ActivityType.CREATE)
 
@@ -103,6 +124,8 @@ def test_acitivty(client):
     )
     activity.save()
     assert cmp_activity(activity, DBActivity.load_with_db_id(db_id=activity.id))
+    time.sleep(ttl)
+    assert DBActivity.count.count() == 2
 
     comment_body = "test comment"
     comment_id1 = 1
@@ -119,6 +142,7 @@ def test_acitivty(client):
     )
 
     comment1.save()
+
     activity1 = DBActivity(
         user_id=user.id, activity=ActivityType.CREATE, comment_id=comment1.id
     )

--- a/tests/db/test_cache.py
+++ b/tests/db/test_cache.py
@@ -1,0 +1,51 @@
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2022 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import time
+
+import pytest
+
+from interface.db import get_db
+from interface.db.cache import CACHE_TTL, RecordCount
+from interface.db.repo import DBRepo
+from interface.db.issues import DBIssue
+from interface.db.users import DBUser
+from interface.db.webfinger import INTERFACE_BASE_URL, INTERFACE_DOMAIN
+
+
+def test_cache(client):
+    """Test DB record count cache"""
+
+    assert (
+        DBUser.count.count() == 1
+    )  # interface registers Interface user(bot user) on startup
+
+    ttl = 2 * CACHE_TTL
+    name = "db_test_user"
+    user_id = name
+    user = DBUser(
+        name=name,
+        user_id=user_id,
+        profile_url=f"https://git.batsense.net/{user_id}",
+        avatar_url=f"https://git.batsense.net/{user_id}",
+        description="description",
+    )
+
+    assert DBUser.load(user_id) is None
+    assert DBUser.load_with_db_id(11) is None
+
+    user.save()
+    assert DBUser.count.count() == 1
+    time.sleep(ttl)
+    assert DBUser.count.count() == 2

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from urllib.parse import urlparse
 
-from interface.db import INTERFACE_DOMAIN
+from interface.db import INTERFACE_DOMAIN, DBUser, get_db
 from interface.git import get_user
 from interface.utils import CONTENT_TYPE_ACTIVITY_JSON
 
@@ -24,7 +24,9 @@ from .forges.gitea.test_utils import REPOSITORY_OWNER
 def test_user_actor(client, requests_mock):
     """Test user actor info route"""
     assert INTERFACE_DOMAIN != "example.com"  # Please change domain settings
+
     user = get_user(REPOSITORY_OWNER)
+
     item = [
         item
         for item in user.webfinger()["links"]


### PR DESCRIPTION
> blocked by #82

monthly active and half-yearly active users are some of the metrics exposed via nodeinfo. This PR implements those metrics retrieval with caching