### PR TITLE
fix: Port for the server is now dynamically loaded

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -22,7 +22,6 @@ cache_ttl = 3600 # in seconds
 
 [default.server]
 url = "http://localhost:2000" # URL at which this interface will run
-port = 2000
 
 [testing]
 forge = "gitea"

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -17,11 +17,12 @@ forge = "gitea"
 base_dir = "/tmp/" # Location where git repositories will be cloned into
 admin_email = "foo@a.com" # Committing email
 job_runner_delay = 1  ## in seconds
-northstar = "https://northstar.forgefed.io" # Default discovery service URL
+northstar = "http://northstar.forgeflux.org" # Default discovery service URL
 cache_ttl = 3600 # in seconds
 
 [default.server]
-url = "http://localhost:7000" # URL at which this interface will run
+url = "http://localhost:2000" # URL at which this interface will run
+port = 2000
 
 [testing]
 forge = "gitea"

--- a/interface/__main__.py
+++ b/interface/__main__.py
@@ -41,5 +41,6 @@ if __name__ == "__main__":
 
     Init(app=app)
     # worker = runner.init_app(app)
-    app.run(threaded=True, host="0.0.0.0", port=settings.SERVER.port)
+    port = int(settings.SERVER.url.split(":").pop())
+    app.run(threaded=True, host="0.0.0.0", port=port)
     # worker.kill()

--- a/interface/__main__.py
+++ b/interface/__main__.py
@@ -19,6 +19,7 @@ Run ForgeFed Interface flask application
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import time
 from threading import Thread
+from dynaconf import settings
 
 from interface.app import create_app
 from interface.runner import runner
@@ -40,5 +41,5 @@ if __name__ == "__main__":
 
     Init(app=app)
     # worker = runner.init_app(app)
-    app.run(threaded=True, host="0.0.0.0", port=8000)
+    app.run(threaded=True, host="0.0.0.0", port=settings.SERVER.port)
     # worker.kill()


### PR DESCRIPTION
This PR intends to fix #87 

## Changelog
The port is now loaded through Dynaconf.
The configuration has been updated with a port option, and the northstar field has been updated to the hit `forgeflux.org` instead of the previous `forgedfed.io`.
