### PR TITLE
fix: Uses the latest configuration setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,3 @@ grcov.tar.bz2
 lcov.info
 *.profraw
 lcov.info
-config/.secrets.toml

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ grcov.tar.bz2
 lcov.info
 *.profraw
 lcov.info
+config/.secrets.toml

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ lint: ## Run linter
 	@./venv/bin/black ./interface/*
 	@./venv/bin/black ./tests/*
 	@./venv/bin/black ./migrations/*
+	@./venv/bin/black setup.py
 	. ./venv/bin/activate && ./scripts/spellcheck.sh --check #--write
 
 migrate: ## Run migrations

--- a/interface/__main__.py
+++ b/interface/__main__.py
@@ -19,8 +19,8 @@ Run ForgeFed Interface flask application
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import time
 from threading import Thread
-from dynaconf import settings
 
+from interface.settings import settings
 from interface.app import create_app
 from interface.runner import runner
 from interface.git import get_forge
@@ -35,6 +35,7 @@ class Init:
         with self.app.app_context():
             time.sleep(3)
             get_forge()
+
 
 if __name__ == "__main__":
     app = create_app()

--- a/interface/db/activity.py
+++ b/interface/db/activity.py
@@ -16,7 +16,7 @@ from enum import Enum, unique
 from dataclasses import dataclass
 from functools import lru_cache
 
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.utils import since_epoch
 from .conn import get_db

--- a/interface/db/cache.py
+++ b/interface/db/cache.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from functools import lru_cache
 
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.utils import since_epoch
 from .conn import get_db

--- a/interface/db/conn.py
+++ b/interface/db/conn.py
@@ -23,7 +23,7 @@ from yoyo import read_migrations
 from yoyo import get_backend
 from libgit import System
 
-from dynaconf import settings
+from interface.settings import settings
 
 
 def get_db() -> sqlite3.Connection:

--- a/interface/db/interfaces.py
+++ b/interface/db/interfaces.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from dataclasses import dataclass
-from dynaconf import settings
+from interface.settings import settings
 from flask import g
 
 from .conn import get_db

--- a/interface/db/webfinger.py
+++ b/interface/db/webfinger.py
@@ -12,7 +12,7 @@
 # GNU Affero General Public License for more details.
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from dynaconf import settings
+from interface.settings import settings
 from urllib.parse import urlparse
 
 from interface.utils import trim_url

--- a/interface/forges/gitea/admin.py
+++ b/interface/forges/gitea/admin.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from dynaconf import settings
+from interface.settings import settings
 from flask import g
 
 from interface.utils import clean_url, trim_url

--- a/interface/forges/gitea/gitea.py
+++ b/interface/forges/gitea/gitea.py
@@ -21,7 +21,7 @@ from dateutil.parser import parse as date_parse
 import requests
 
 from rfc3339 import rfc3339
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.forges.base import (
     Forge,

--- a/interface/forges/gitea/html_client.py
+++ b/interface/forges/gitea/html_client.py
@@ -23,7 +23,7 @@ from requests import Session
 from requests.auth import HTTPBasicAuth
 
 from rfc3339 import rfc3339
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.forges.base import (
     Forge,

--- a/interface/forges/gitea/notifications.py
+++ b/interface/forges/gitea/notifications.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from dateutil.parser import parse as date_parse
 
 from flask import current_app
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.forges.notifications import (
     CreatePrEvent,

--- a/interface/forges/gitea/responses.py
+++ b/interface/forges/gitea/responses.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 import requests
 
 # from flask import current_app
-from dynaconf import settings
+from interface.settings import settings
 
 #
 # from interface.forges.notifications import (

--- a/interface/forges/gitea/utils.py
+++ b/interface/forges/gitea/utils.py
@@ -18,7 +18,7 @@ Gitea-specific utilities
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from urllib.parse import urlparse
 
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.utils import trim_url
 from interface.forges.base import F_D_INVALID_ISSUE_URL

--- a/interface/forges/github.py
+++ b/interface/forges/github.py
@@ -21,7 +21,7 @@ from dataclasses import asdict
 import requests
 from rfc3339 import rfc3339
 
-from dynaconf import settings
+from interface.settings import settings
 from . import utils
 from .base import CreateIssue, Forge, RepositoryInfo, CreatePullrequest
 from .notifications import Notification, Comment, NotificationResp

--- a/interface/git.py
+++ b/interface/git.py
@@ -22,7 +22,7 @@ import rfc3339
 from flask import g
 
 from libgit import InterfaceAdmin, Repo, Patch, System
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.db import get_db, get_git_system, DBUser, DBRepo, DBIssue
 from interface.forges.utils import get_branch_name

--- a/interface/ns.py
+++ b/interface/ns.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 
 import requests
 
-from dynaconf import settings
+from interface.settings import settings
 from interface.utils import clean_url, since_epoch, trim_url
 from interface.error import Error
 

--- a/interface/runner/events.py
+++ b/interface/runner/events.py
@@ -18,7 +18,7 @@ A job runner that receives events(notifications) and runs relevant jobs on them
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from dataclasses import dataclass
 import requests
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.git import get_forge
 from interface.db import get_db

--- a/interface/runner/runner.py
+++ b/interface/runner/runner.py
@@ -26,7 +26,7 @@ from dateutil.parser import parse as date_parse
 
 from flask import g
 
-from dynaconf import settings
+from interface.settings import settings
 from interface.git import get_forge
 from interface.forges.notifications import PULL, ISSUE
 from interface.forges.utils import get_patch, get_branch_name

--- a/interface/settings.py
+++ b/interface/settings.py
@@ -1,5 +1,9 @@
 import socket
 
-from dynaconf import settings
+from dynaconf import Dynaconf
 
-settings = settings
+settings = Dynaconf(
+    envvar_prefix="INTERFACE",
+    environments=True,
+    settings_files=["settings.toml"]
+)

--- a/interface/settings.py
+++ b/interface/settings.py
@@ -3,7 +3,5 @@ import socket
 from dynaconf import Dynaconf
 
 settings = Dynaconf(
-    envvar_prefix="INTERFACE",
-    environments=True,
-    settings_files=["settings.toml"]
+    envvar_prefix="INTERFACE", environments=True, settings_files=["settings.toml"]
 )

--- a/interface/user.py
+++ b/interface/user.py
@@ -21,7 +21,7 @@ from dataclasses import asdict
 import json
 
 from flask import Blueprint, jsonify, Response, request, redirect
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.db import DBIssue, DBUser, DBRepo, INTERFACE_DOMAIN
 from interface.git import get_forge, get_user

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='interface',
-    version='0.1.0',
+    name="interface",
+    version="0.1.0",
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'flask[async]',
+        "flask[async]",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import tempfile
 
 import pytest
 import requests_mock
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.app import create_app
 from interface.db import get_db, init_db

--- a/tests/db/test_activity.py
+++ b/tests/db/test_activity.py
@@ -16,7 +16,7 @@ import time
 from datetime import datetime
 
 import pytest
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.db import get_db, DBActivity, ActivityType, DBComment
 from interface.db.cache import CACHE_TTL

--- a/tests/db/test_interface.py
+++ b/tests/db/test_interface.py
@@ -12,7 +12,7 @@
 # GNU Affero General Public License for more details.
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.db.interfaces import DBInterfaces
 from interface.app import app

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -15,7 +15,7 @@
 from urllib.parse import urlparse, urlunparse
 from dateutil.parser import parse
 
-from dynaconf import settings
+from interface.settings import settings
 import pytest
 
 from interface.utils import get_rand

--- a/tests/forges/gitea/test_utils.py
+++ b/tests/forges/gitea/test_utils.py
@@ -20,7 +20,7 @@ from urllib.parse import parse_qs, urlparse
 
 from requests import Request
 from requests_mock import CookieJar
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.utils import trim_url
 from interface.forges.payload import CreateIssue

--- a/tests/forges/test_base.py
+++ b/tests/forges/test_base.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from urllib.parse import urlparse, urlunparse
 
 import pytest
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.forges.base import Forge
 from interface.forges.payload import (

--- a/tests/runner/test_resolve_notifications.py
+++ b/tests/runner/test_resolve_notifications.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 import pytest
 from rfc3339 import rfc3339
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.app import create_app
 from interface.forges.notifications import ISSUE, PULL, Notification, Comment

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.git import Git, get_forge
 

--- a/tests/test_ns.py
+++ b/tests/test_ns.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import time
 
-from dynaconf import settings
+from interface.settings import settings
 from interface.ns import NameService
 from interface.git import get_forge
 from interface.utils import clean_url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from urllib.parse import urlparse, urlunparse
 from datetime import datetime, timezone
-from dynaconf import settings
+from interface.settings import settings
 
 from interface.app import create_app
 from interface.utils import clean_url, trim_url, since_epoch, from_epoch


### PR DESCRIPTION
This PR fixes #28.
## Changelog
Dynaconf threw a warning about deprecated import methodology for `interface`, so updated it.

- [x] Dynaconf configuration upgrade.
- [x] Simple black format.
- [x] Ignore `.secrets.toml`.
- [x] Set up an environment prefix for interface.