### PR TITLE
chore: libgit: update git2-rs rust dep

### DIFF
--- a/libgit/Cargo.lock
+++ b/libgit/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.23"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
+checksum = "6e7d3b96ec1fcaa8431cf04a4f1ef5caafe58d5cf7bcc31f09c1626adddb0ffe"
 dependencies = [
  "bitflags",
  "libc",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.24+1.3.0"
+version = "0.13.1+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
+checksum = "43e598aa7a4faedf1ea1b4608f582b06f0f40211eec551b7ef36019ae3f62def"
 dependencies = [
  "cc",
  "libc",

--- a/libgit/Cargo.toml
+++ b/libgit/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-git2 = "0.13.23"
+git2 = "0.14.1"
 url = "2.2"
 thiserror = "1.0.30"
 validator = "0.14.0"


### PR DESCRIPTION
WARNING
    Kindly delete virtual environment and then re-install dependencies.

FIXES

```
    Finished dev [unoptimized + debuginfo] target(s) in 6.46s
⚠️  Warning: No compatible platform tag found, using the linux tag instead. You won't be able to upload those wheels to PyPI.
📦 Built wheel for CPython 3.10 to code/forgedfed/interface/libgit/target/wheels/libgit-0.1.0-cp310-cp310-linux_x86_64.whl
. ./venv/bin/activate && python -m interface
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "code/forgedfed/interface/interface/__main__.py", line 23, in <module>
    from interface.app import create_app
  File "code/forgedfed/interface/interface/app.py", line 23, in <module>
    from interface import db
  File "code/forgedfed/interface/interface/db/__init__.py", line 15, in <module>
    from .conn import init_app, get_db, get_git_system, init_db
  File "code/forgedfed/interface/interface/db/conn.py", line 24, in <module>
    from libgit import System
  File "code/forgedfed/interface/venv/lib/python3.10/site-packages/libgit/__init__.py", line 1, in <module>
    from .libgit import *
ImportError: libgit2.so.1.3: cannot open shared object file: No such file or directory
make: *** [Makefile:29: default] Error 1
```